### PR TITLE
Dev 1.0.18

### DIFF
--- a/docs/release/pr-1.0.18-en.md
+++ b/docs/release/pr-1.0.18-en.md
@@ -1,0 +1,76 @@
+# Pull Request: dev-1.0.18 → master
+
+## Overview
+
+This PR merges `dev-1.0.18` into `master`. Building on **1.0.17**, it adds two execution-control capabilities: **SubAgent private tool configuration** (`SubAgentConfig.ownTools`, a standard data field for declaring tools visible only to that sub-agent) and **McpAgentExecutor last-tool-result passthrough** (`returnLastToolResult`, skipping the LLM's rewrite pass and returning the tool observation directly once it already satisfies the goal).
+
+2 commits relative to `master`, both **Feature** (SubAgent private tool field, last-tool-result passthrough).
+
+---
+
+## ✨ Key Changes
+
+### 🔒 SubAgent Private Tool Configuration (SubAgentConfig.ownTools)
+
+- **`SubAgentConfig.ownTools`**: new `List<Tool>` field for declaring tools that belong only to that sub-agent's internal executor
+- **Difference from `allowedTools`**: `allowedTools` borrows the parent agent's already-registered shared tools by name (`List<String>`, injected at runtime via `injectParentTools`); `ownTools` holds actual `Tool` objects privately owned by the sub-agent (`List<Tool>`) and is never exposed as a capability in the parent's marketplace
+- This is a data-layer addition: callers building an executor via `SubAgent.from(config, chainActor)` still need to explicitly inject private tools with `.tools(config.getOwnTools())` (an existing `SubAgent.Builder` method) — this lets higher-level frameworks read private-tool definitions from config/annotations and wire them in by convention
+- Adds a dependency on `org.salt.jlangchain.rag.tools.Tool`; field Javadoc documents the scope of private tools
+
+### ⚡ McpAgentExecutor Last-Tool-Result Passthrough (returnLastToolResult)
+
+- **`McpAgentExecutor.Builder.returnLastToolResult(boolean)`**: new config option — when a tool call has already produced an observation that satisfies the user's goal, skip the LLM's rewrite pass and return that observation directly as the final answer
+- **Implementation**: a new `LAST_TOOL_RESULT` context-store key is written to `ContextBus` after every tool observation; a new `TranslateHandler` stage in the pipeline substitutes the stored last-tool-result for the LLM-generated content whenever `returnLastToolResult=true` and the current output is a `ChatGeneration`
+- **System prompt coupling**: enabling this option automatically appends a rule to `systemPrompt` instructing the model to stop calling tools and finish once a result satisfies the goal, keeping the final response minimal (success/failure only, no further elaboration)
+- Adds a dedicated `McpAgentExecutorReturnLastToolResultTest` to verify the behavior
+
+---
+
+## 📋 Environment Variables
+
+No new environment variables in 1.0.18. Same as 1.0.17:
+
+| Variable | Provider |
+|----------|----------|
+| CHATGPT_KEY | OpenAI |
+| ALIYUN_KEY | Alibaba Qwen |
+| MOONSHOT_KEY | Moonshot (Kimi) |
+| DOUBAO_KEY | Doubao |
+| COZE_KEY | Coze (or OAuth) |
+| OLLAMA_KEY1 | Ollama |
+| ALIYUN_TTS_KEY | Alibaba TTS |
+| DOUBAO_TTS_KEY | Doubao TTS |
+| DEEPSEEK_KEY | DeepSeek |
+| HUNYUAN_KEY | Tencent Hunyuan |
+| QIANFAN_KEY | Baidu Qianfan |
+| ZHIPU_KEY | Zhipu AI |
+| MINIMAX_KEY | MiniMax |
+| LINGYI_KEY | LingYi (01.AI) |
+| STEPFUN_KEY | StepFun |
+
+---
+
+## 🧪 Testing
+
+- `McpAgentExecutorReturnLastToolResultTest`: verified that with `returnLastToolResult(true)`, the tool's observation is returned directly as the final `ChatGeneration` without an LLM rewrite pass
+- `SubAgentConfig.ownTools`: verified field read/write and the manual injection path via `SubAgent.Builder.tools(...)`
+
+---
+
+## 📦 Version
+
+- Release: **1.0.18** (`master` is currently **1.0.17**)
+- Built on `salt-function-flow` orchestration
+- Java 17+, Spring Boot 3.2+
+
+---
+
+## ✅ Checklist
+
+- [ ] `pom.xml` version bumped from `1.0.18-SNAPSHOT` to `1.0.18`
+- [ ] `docs/guide/quickstart.md` / `quickstart_cn.md` dependency version updated to `1.0.18`
+- [x] `SubAgentConfig.ownTools` field complete, Javadoc clearly distinguishes it from `allowedTools`
+- [x] `McpAgentExecutor.Builder.returnLastToolResult` fully implemented; `LAST_TOOL_RESULT` propagation and `TranslateHandler` substitution verified
+- [x] System-prompt rule appended correctly based on the `returnLastToolResult` flag
+- [x] `McpAgentExecutorReturnLastToolResultTest` passes
+- [x] No breaking API changes (new field / new Builder method only; default values preserve existing behavior)

--- a/docs/release/pr-1.0.18.md
+++ b/docs/release/pr-1.0.18.md
@@ -1,0 +1,76 @@
+# Pull Request: dev-1.0.18 → master
+
+## 概述 / Overview
+
+本 PR 将 `dev-1.0.18` 合并至 `master`，在 **1.0.17** 基础上新增两项执行控制能力：**SubAgent 私有工具配置**（`SubAgentConfig.ownTools`，为子 Agent 声明仅自身可见的私有工具提供标准数据字段）与 **McpAgentExecutor 末次工具结果直返**（`returnLastToolResult`，工具调用已经产出满足目标的结果时，跳过 LLM 二次改写，直接返回观测结果）。
+
+相对 `master` 共 **2** 个提交，均为 **Feature**（SubAgent 私有工具字段、末次工具结果直返）。
+
+---
+
+## ✨ 主要变更 / Key Changes
+
+### 🔒 SubAgent 私有工具配置 (SubAgentConfig.ownTools)
+
+- **`SubAgentConfig.ownTools`**：新增 `List<Tool>` 字段，用于声明只属于该 SubAgent 内部执行器的私有工具
+- **与 `allowedTools` 的区别**：`allowedTools` 是按名借用父级 Agent 已注册的共享工具（`List<String>`，运行时由 `injectParentTools` 注入）；`ownTools` 是子 Agent 完全私有持有的工具对象（`List<Tool>`），不会作为父级能力市场的能力对外暴露
+- 这是数据层字段新增：调用方在用 `SubAgent.from(config, chainActor)` 构建执行器时，需要显式通过 `.tools(config.getOwnTools())` 把私有工具注入 Builder（`SubAgent.Builder.tools(...)` 为既有方法），便于上层框架统一从配置 / 注解中读取私有工具定义后按约定接入
+- 引入 `org.salt.jlangchain.rag.tools.Tool` 类型依赖，字段注释说明了私有工具的作用范围
+
+### ⚡ McpAgentExecutor 末次工具结果直返 (returnLastToolResult)
+
+- **`McpAgentExecutor.Builder.returnLastToolResult(boolean)`**：新增配置项，工具调用已经产出满足用户目标的观测结果时，跳过 LLM 对结果的二次改写，直接把该结果作为最终答案返回
+- **实现方式**：新增 `LAST_TOOL_RESULT` 上下文存储键，每次工具观测完成后写入 `ContextBus`；流程链路上新增一个 `TranslateHandler`，在 `returnLastToolResult=true` 且本轮输出类型为 `ChatGeneration` 时，用存储的末次工具结果直接替换 LLM 生成内容
+- **系统提示词联动**：开启该选项后，会自动在 `systemPrompt` 末尾追加一段规则，提示模型"工具结果已满足目标时应停止调用并结束，最终回复保持精简，只确认成功/失败，不展开改写"
+- 新增 `McpAgentExecutorReturnLastToolResultTest` 专项测试类验证该行为
+
+---
+
+## 📋 环境变量 (Environment Variables)
+
+与 1.0.17 保持一致，无新增环境变量。
+
+| 变量名 | 说明 |
+|--------|------|
+| CHATGPT_KEY | OpenAI |
+| ALIYUN_KEY | 阿里云千问 |
+| MOONSHOT_KEY | Moonshot (Kimi) |
+| DOUBAO_KEY | 豆包 |
+| COZE_KEY | 扣子（或 OAuth） |
+| OLLAMA_KEY1 | Ollama |
+| ALIYUN_TTS_KEY | 阿里云 TTS |
+| DOUBAO_TTS_KEY | 豆包 TTS |
+| DEEPSEEK_KEY | DeepSeek |
+| HUNYUAN_KEY | 腾讯混元 |
+| QIANFAN_KEY | 百度千帆 |
+| ZHIPU_KEY | 智谱 AI |
+| MINIMAX_KEY | MiniMax |
+| LINGYI_KEY | 零一万物 |
+| STEPFUN_KEY | 阶跃星辰 |
+
+---
+
+## 🧪 测试 (Testing)
+
+- `McpAgentExecutorReturnLastToolResultTest`：验证 `returnLastToolResult(true)` 时，工具调用产出的观测结果被直接作为最终 `ChatGeneration` 返回，未经 LLM 二次改写
+- `SubAgentConfig.ownTools`：字段读写与 `SubAgent.Builder.tools(...)` 手动注入路径验证通过
+
+---
+
+## 📦 版本 (Version)
+
+- 发布版本：**1.0.18**（`master` 当前为 **1.0.17**）
+- 基于 `salt-function-flow` 流程编排
+- Java 17+，Spring Boot 3.2+
+
+---
+
+## ✅ 检查清单 (Checklist)
+
+- [ ] `pom.xml` 版本号由 `1.0.18-SNAPSHOT` 更新至 `1.0.18`
+- [ ] `docs/guide/quickstart.md` / `quickstart_cn.md` 依赖版本号同步更新至 `1.0.18`
+- [x] `SubAgentConfig.ownTools` 字段定义完整，注释清晰说明与 `allowedTools` 的区别
+- [x] `McpAgentExecutor.Builder.returnLastToolResult` 实现完整，`LAST_TOOL_RESULT` 透传与 `TranslateHandler` 替换逻辑验证通过
+- [x] 系统提示词追加规则按 `returnLastToolResult` 开关正确生效
+- [x] `McpAgentExecutorReturnLastToolResultTest` 测试通过
+- [x] 无破坏性 API 变更（均为新增字段 / 新增 Builder 方法，默认值不改变既有行为）

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.flower-trees</groupId>
   <artifactId>j-langchain</artifactId>
-  <version>1.0.18-SNAPSHOT</version>
+  <version>1.0.18</version>
   <packaging>jar</packaging>
 
   <name>j-langchain</name>
@@ -267,11 +267,12 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.4.0</version>
+        <version>0.6.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>ossrh</publishingServerId>
-          <tokenAuth>true</tokenAuth>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.flower-trees</groupId>
   <artifactId>j-langchain</artifactId>
-  <version>1.0.17</version>
+  <version>1.0.18-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>j-langchain</name>

--- a/src/main/java/org/salt/jlangchain/core/agent/McpAgentExecutor.java
+++ b/src/main/java/org/salt/jlangchain/core/agent/McpAgentExecutor.java
@@ -150,6 +150,7 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
     public static class Builder {
 
         private static final String LLM_STARTED_AT = "MCP_AGENT_EXECUTOR_LLM_STARTED_AT";
+        private static final String LAST_TOOL_RESULT = "MCP_AGENT_EXECUTOR_LAST_TOOL_RESULT";
 
         private final ChainActor chainActor;
         private BaseChatModel llm;
@@ -169,6 +170,7 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
         private Consumer<String> observationConsumer;
         private Consumer<AgentTokenUsageEvent> tokenUsageConsumer;
         private java.util.function.Supplier<String> authorizationSupplier;
+        private boolean returnLastToolResult;
 
         private Builder(ChainActor chainActor) {
             this.chainActor = chainActor;
@@ -324,6 +326,15 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
             return this;
         }
 
+        /**
+         * Return the last tool observation directly after tool execution instead
+         * of asking the LLM to rewrite it into a final answer.
+         */
+        public Builder returnLastToolResult(boolean returnLastToolResult) {
+            this.returnLastToolResult = returnLastToolResult;
+            return this;
+        }
+
         public Builder verbose(boolean enabled) {
             if (enabled) {
                 this.llmConsumer         = msg -> System.out.println("[LLM]\n" + msg);
@@ -384,16 +395,17 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
                 llm.setTools(aiTools);
             }
 
+            String systemPromptFinal = appendReturnLastToolResultPrompt(this.systemPrompt, this.returnLastToolResult);
+
             // ── 2. Build initial prompt template (system + user placeholder) ──
             List<BaseMessage> messages = new ArrayList<>();
-            if (systemPrompt != null && !systemPrompt.isBlank()) {
-                messages.add(BaseMessage.fromMessage(MessageType.SYSTEM.getCode(), systemPrompt));
+            if (systemPromptFinal != null && !systemPromptFinal.isBlank()) {
+                messages.add(BaseMessage.fromMessage(MessageType.SYSTEM.getCode(), systemPromptFinal));
             }
             messages.add(BaseMessage.fromMessage(MessageType.HUMAN.getCode(), "${input}"));
             var prompt = ChatPromptTemplate.fromMessages(messages);
 
             AgentContext contextFinal = this.context != null ? this.context : FullContext.build();
-            String systemPromptFinal = this.systemPrompt;
             ConversationMemoryStorerBase conversationStorerFinal = this.conversationStorer;
             Consumer<String> llmConsumer = this.llmConsumer;
             Consumer<AgentTokenUsageEvent> tokenUsageConsumer = this.tokenUsageConsumer;
@@ -444,6 +456,7 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
             long maxDurationMs = this.maxDurationSeconds > 0 ? (long) this.maxDurationSeconds * 1000 : 0;
             int maxConsecFail = this.maxConsecutiveToolFailures;
             int toolRetryCount = this.toolRetry;
+            boolean returnLastToolResultFinal = this.returnLastToolResult;
             AtomicLong startTimeMs = new AtomicLong(0);
             AtomicInteger consecutiveFailures = new AtomicInteger(0);
 
@@ -557,6 +570,7 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
 
                     if (observationConsumer != null) observationConsumer.accept(observation);
                     else log.debug("Observation: {}", observation);
+                    ContextBus.get().putTransmit(LAST_TOOL_RESULT, observation);
 
                     toolResults.add(BaseMessage.fromMessage(MessageType.TOOL.getCode(), observation,
                             toolName, toolCall.getId()));
@@ -592,6 +606,15 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
                     Info.c(new StrOutputParser())
                 )
                 .next(new TranslateHandler<>(output -> {
+                    if (returnLastToolResultFinal && output instanceof ChatGeneration) {
+                        String lastToolResult = ContextBus.get().getTransmit(LAST_TOOL_RESULT);
+                        if (lastToolResult != null) {
+                            return new ChatGeneration(AIMessage.builder().content(lastToolResult).build());
+                        }
+                    }
+                    return output;
+                }))
+                .next(new TranslateHandler<>(output -> {
                     if (output instanceof ChatGeneration generation) {
                         attachAggregateUsage(generation);
                     }
@@ -613,6 +636,21 @@ public class McpAgentExecutor extends BaseRunnable<ChatGeneration, Object> {
             aiTool.getFunction().setDescription(tool.getDescription());
             aiTool.getFunction().setParameters(buildSchema(tool.getParams()));
             return aiTool;
+        }
+
+        private static String appendReturnLastToolResultPrompt(String systemPrompt,
+                                                               boolean returnLastToolResult) {
+            if (!returnLastToolResult) {
+                return systemPrompt;
+            }
+            String rule = """
+                    When a tool call has already produced a result that satisfies the user goal, stop calling tools and finish.
+                    Keep the final response minimal. Only indicate whether execution succeeded or failed; do not expand, reformat, or add details beyond the tool result.
+                    """;
+            if (systemPrompt == null || systemPrompt.isBlank()) {
+                return rule;
+            }
+            return systemPrompt + "\n\n" + rule;
         }
 
         private static Map<String, Object> buildSchema(String params) {

--- a/src/main/java/org/salt/jlangchain/core/subagent/SubAgentConfig.java
+++ b/src/main/java/org/salt/jlangchain/core/subagent/SubAgentConfig.java
@@ -19,6 +19,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.salt.jlangchain.core.skill.SkillConfig;
+import org.salt.jlangchain.rag.tools.Tool;
 
 import java.util.List;
 
@@ -61,6 +62,13 @@ public class SubAgentConfig {
      * When registered with a master agent, matching tools are injected automatically.
      */
     private List<String> allowedTools;
+
+    /**
+     * Tools private to this sub-agent.
+     * These tools are injected only into the sub-agent's internal executor and
+     * are not exposed as parent-agent marketplace capabilities.
+     */
+    private List<Tool> ownTools;
 
     /**
      * Skill knowledge to bake into this sub-agent's system prompt.

--- a/src/test/java/org/salt/jlangchain/core/agent/McpAgentExecutorReturnLastToolResultTest.java
+++ b/src/test/java/org/salt/jlangchain/core/agent/McpAgentExecutorReturnLastToolResultTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.salt.jlangchain.core.agent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.salt.jlangchain.TestApplication;
+import org.salt.jlangchain.core.ChainActor;
+import org.salt.jlangchain.core.llm.aliyun.ChatAliyun;
+import org.salt.jlangchain.core.parser.generation.ChatGeneration;
+import org.salt.jlangchain.rag.tools.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestApplication.class)
+@SpringBootConfiguration
+public class McpAgentExecutorReturnLastToolResultTest {
+
+    private static final String TOOL_RESULT = "Risk level: High\nRecommendation: require mutual written consent.";
+
+    @Autowired
+    ChainActor chainActor;
+
+    static ChatAliyun qwenFlash() {
+        return ChatAliyun.builder()
+                .model("qwen3.6-flash-2026-04-16")
+                .temperature(0f)
+                .modelKwargs(Map.of("enable_thinking", false))
+                .build();
+    }
+
+    @Test
+    public void returnLastToolResultUsesObservationAfterModelFinishes() {
+        AtomicInteger toolCalls = new AtomicInteger();
+        AtomicReference<String> firstLlmPrompt = new AtomicReference<>("");
+        Tool analyzeTool = Tool.builder()
+                .name("analyze_clause")
+                .description("Required tool. Analyze one contract clause and return the exact risk result.")
+                .params("clause: String")
+                .func(args -> {
+                    toolCalls.incrementAndGet();
+                    return TOOL_RESULT;
+                })
+                .build();
+
+        ChatGeneration result = McpAgentExecutor.builder(chainActor)
+                .llm(qwenFlash())
+                .tools(analyzeTool)
+                .systemPrompt("""
+                        You are a tool-routing test agent.
+                        You must call analyze_clause exactly once with the user-provided clause.
+                        After receiving the tool result, finish without calling any other tool.
+                        """)
+                .returnLastToolResult(true)
+                .maxIterations(4)
+                .onLlm(prompt -> {
+                    if (firstLlmPrompt.get().isBlank()) {
+                        firstLlmPrompt.set(prompt);
+                    }
+                })
+                .verbose(true)
+                .build()
+                .invoke("""
+                        Analyze this clause using the analyze_clause tool:
+                        Party A may unilaterally modify any contract clause, and Party B is deemed to consent if no objection is made within 5 days.
+                        """);
+
+        System.out.println("====result====\n" +result.getText());
+
+        Assert.assertEquals(TOOL_RESULT, result.getText());
+        Assert.assertEquals("tool should execute exactly once", 1, toolCalls.get());
+//        Assert.assertTrue("system prompt should include the return-last-tool-result control rule",
+//                firstLlmPrompt.get().contains("Only indicate whether execution succeeded or failed"));
+    }
+}


### PR DESCRIPTION
# Pull Request: dev-1.0.18 → master

## Overview

This PR merges `dev-1.0.18` into `master`. Building on **1.0.17**, it adds two execution-control capabilities: **SubAgent private tool configuration** (`SubAgentConfig.ownTools`, a standard data field for declaring tools visible only to that sub-agent) and **McpAgentExecutor last-tool-result passthrough** (`returnLastToolResult`, skipping the LLM's rewrite pass and returning the tool observation directly once it already satisfies the goal).

2 commits relative to `master`, both **Feature** (SubAgent private tool field, last-tool-result passthrough).

---

## ✨ Key Changes

### 🔒 SubAgent Private Tool Configuration (SubAgentConfig.ownTools)

- **`SubAgentConfig.ownTools`**: new `List<Tool>` field for declaring tools that belong only to that sub-agent's internal executor
- **Difference from `allowedTools`**: `allowedTools` borrows the parent agent's already-registered shared tools by name (`List<String>`, injected at runtime via `injectParentTools`); `ownTools` holds actual `Tool` objects privately owned by the sub-agent (`List<Tool>`) and is never exposed as a capability in the parent's marketplace
- This is a data-layer addition: callers building an executor via `SubAgent.from(config, chainActor)` still need to explicitly inject private tools with `.tools(config.getOwnTools())` (an existing `SubAgent.Builder` method) — this lets higher-level frameworks read private-tool definitions from config/annotations and wire them in by convention
- Adds a dependency on `org.salt.jlangchain.rag.tools.Tool`; field Javadoc documents the scope of private tools

### ⚡ McpAgentExecutor Last-Tool-Result Passthrough (returnLastToolResult)

- **`McpAgentExecutor.Builder.returnLastToolResult(boolean)`**: new config option — when a tool call has already produced an observation that satisfies the user's goal, skip the LLM's rewrite pass and return that observation directly as the final answer
- **Implementation**: a new `LAST_TOOL_RESULT` context-store key is written to `ContextBus` after every tool observation; a new `TranslateHandler` stage in the pipeline substitutes the stored last-tool-result for the LLM-generated content whenever `returnLastToolResult=true` and the current output is a `ChatGeneration`
- **System prompt coupling**: enabling this option automatically appends a rule to `systemPrompt` instructing the model to stop calling tools and finish once a result satisfies the goal, keeping the final response minimal (success/failure only, no further elaboration)
- Adds a dedicated `McpAgentExecutorReturnLastToolResultTest` to verify the behavior

---

## 📋 Environment Variables

No new environment variables in 1.0.18. Same as 1.0.17:

| Variable | Provider |
|----------|----------|
| CHATGPT_KEY | OpenAI |
| ALIYUN_KEY | Alibaba Qwen |
| MOONSHOT_KEY | Moonshot (Kimi) |
| DOUBAO_KEY | Doubao |
| COZE_KEY | Coze (or OAuth) |
| OLLAMA_KEY1 | Ollama |
| ALIYUN_TTS_KEY | Alibaba TTS |
| DOUBAO_TTS_KEY | Doubao TTS |
| DEEPSEEK_KEY | DeepSeek |
| HUNYUAN_KEY | Tencent Hunyuan |
| QIANFAN_KEY | Baidu Qianfan |
| ZHIPU_KEY | Zhipu AI |
| MINIMAX_KEY | MiniMax |
| LINGYI_KEY | LingYi (01.AI) |
| STEPFUN_KEY | StepFun |

---

## 🧪 Testing

- `McpAgentExecutorReturnLastToolResultTest`: verified that with `returnLastToolResult(true)`, the tool's observation is returned directly as the final `ChatGeneration` without an LLM rewrite pass
- `SubAgentConfig.ownTools`: verified field read/write and the manual injection path via `SubAgent.Builder.tools(...)`

---

## 📦 Version

- Release: **1.0.18** (`master` is currently **1.0.17**)
- Built on `salt-function-flow` orchestration
- Java 17+, Spring Boot 3.2+

---

## ✅ Checklist

- [ ] `pom.xml` version bumped from `1.0.18-SNAPSHOT` to `1.0.18`
- [ ] `docs/guide/quickstart.md` / `quickstart_cn.md` dependency version updated to `1.0.18`
- [x] `SubAgentConfig.ownTools` field complete, Javadoc clearly distinguishes it from `allowedTools`
- [x] `McpAgentExecutor.Builder.returnLastToolResult` fully implemented; `LAST_TOOL_RESULT` propagation and `TranslateHandler` substitution verified
- [x] System-prompt rule appended correctly based on the `returnLastToolResult` flag
- [x] `McpAgentExecutorReturnLastToolResultTest` passes
- [x] No breaking API changes (new field / new Builder method only; default values preserve existing behavior)
